### PR TITLE
Declare Hypothesis dependency, add framework classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,9 @@ setuptools.setup(
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
+        "Framework :: Hypothesis",
+    ],
+    install_requires=[
+        "hypothesis>=6.41.0",
     ],
 )


### PR DESCRIPTION
This should help people install your package, and the classifier helps to find it.

(that said, I've peeked at the implementation and it doesn't look like you're actually using Hypothesis' `@given()` decorator, which means that `@example()` and `note()` won't be doing much.  Do you actually *want* the dependency?)